### PR TITLE
add improved component container for image pipeline

### DIFF
--- a/rmoss_cam/CMakeLists.txt
+++ b/rmoss_cam/CMakeLists.txt
@@ -50,6 +50,9 @@ ament_target_dependencies(${PROJECT_NAME} ${dependencies})
 add_executable(component_container src/component_container.cpp)
 target_link_libraries(component_container ${PROJECT_NAME})
 
+add_executable(benchmark_test src/benchmark_test_main.cpp)
+target_link_libraries(benchmark_test ${PROJECT_NAME})
+
 # register component nodes and generate executable
 rclcpp_components_register_node(${PROJECT_NAME}
   PLUGIN "rmoss_cam::UsbCamNode"
@@ -72,7 +75,7 @@ install(TARGETS ${PROJECT_NAME}
 )
 
 # Install executable nodes
-install(TARGETS component_container
+install(TARGETS component_container benchmark_test
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/rmoss_cam/CMakeLists.txt
+++ b/rmoss_cam/CMakeLists.txt
@@ -47,6 +47,9 @@ set(dependencies
 )
 ament_target_dependencies(${PROJECT_NAME} ${dependencies})
 
+add_executable(component_container src/component_container.cpp)
+target_link_libraries(component_container ${PROJECT_NAME})
+
 # register component nodes and generate executable
 rclcpp_components_register_node(${PROJECT_NAME}
   PLUGIN "rmoss_cam::UsbCamNode"
@@ -66,6 +69,11 @@ install(TARGETS ${PROJECT_NAME}
     ARCHIVE DESTINATION lib
     RUNTIME DESTINATION bin
     INCLUDES DESTINATION include
+)
+
+# Install executable nodes
+install(TARGETS component_container
+  DESTINATION lib/${PROJECT_NAME}
 )
 
 # Install  directories

--- a/rmoss_cam/include/rmoss_cam/cam_node_factory.hpp
+++ b/rmoss_cam/include/rmoss_cam/cam_node_factory.hpp
@@ -1,0 +1,57 @@
+// Copyright 2022 RoboMaster-OSS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMOSS_CAM__CAM_NODE_FACTORY_HPP__
+#define RMOSS_CAM__CAM_NODE_FACTORY_HPP__
+
+#include <functional>
+#include <memory>
+
+#include "rclcpp_components/node_factory.hpp"
+#include "rmoss_cam/cam_server_manager.hpp"
+
+namespace rmoss_cam
+{
+
+class CamNodeFactory : public rclcpp_components::NodeFactory
+{
+public:
+  void
+  set_resource_manager(std::shared_ptr<CamServerManager> manager)
+  {
+    manager_ = manager;
+  }
+  std::shared_ptr<CamServerManager> manager_{nullptr};
+};
+
+template<typename NodeT>
+class CamNodeFactoryTemplate : public CamNodeFactory
+{
+public:
+  CamNodeFactoryTemplate() = default;
+  virtual ~CamNodeFactoryTemplate() = default;
+
+  rclcpp_components::NodeInstanceWrapper
+  create_node_instance(const rclcpp::NodeOptions & options) override
+  {
+    auto node = std::make_shared<NodeT>(options);
+    node->set_resource_manager(manager_);
+    return rclcpp_components::NodeInstanceWrapper(
+      node, std::bind(&NodeT::get_node_base_interface, node));
+  }
+};
+
+}  // namespace rmoss_cam
+
+#endif  // RMOSS_CAM__CAM_NODE_FACTORY_HPP__

--- a/rmoss_cam/include/rmoss_cam/register_node_macro.hpp
+++ b/rmoss_cam/include/rmoss_cam/register_node_macro.hpp
@@ -1,0 +1,31 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMOSS_CAM__REGISTER_NODE_MACRO_HPP__
+#define RMOSS_CAM__REGISTER_NODE_MACRO_HPP__
+
+#include "class_loader/class_loader.hpp"
+#include "rclcpp_components/node_factory_template.hpp"
+#include "rmoss_cam/cam_node_factory.hpp"
+
+// refer to https://github.com/ros2/rclcpp/rclcpp_components.
+#define RMOSS_CAM_COMPONENTS_REGISTER_NODE(NodeClass) \
+  CLASS_LOADER_REGISTER_CLASS( \
+    rclcpp_components::NodeFactoryTemplate<NodeClass>, \
+    rclcpp_components::NodeFactory) \
+  CLASS_LOADER_REGISTER_CLASS( \
+    rmoss_cam::CamNodeFactoryTemplate<NodeClass>, \
+    rmoss_cam::CamNodeFactory)
+
+#endif  // RMOSS_CAM__REGISTER_NODE_MACRO_HPP__

--- a/rmoss_cam/include/rmoss_cam/register_node_macro.hpp
+++ b/rmoss_cam/include/rmoss_cam/register_node_macro.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Open Source Robotics Foundation, Inc.
+// Copyright 2022 RoboMaster-OSS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rmoss_cam/include/rmoss_cam/usb_cam_node.hpp
+++ b/rmoss_cam/include/rmoss_cam/usb_cam_node.hpp
@@ -22,6 +22,7 @@
 
 #include "rmoss_cam/usb_cam.hpp"
 #include "rmoss_cam/cam_server.hpp"
+#include "rmoss_cam/cam_server_manager.hpp"
 
 namespace rmoss_cam
 {
@@ -33,6 +34,15 @@ public:
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr get_node_base_interface()
   {
     return node_->get_node_base_interface();
+  }
+  void set_resource_manager(std::shared_ptr<CamServerManager> manager)
+  {
+    // add camera server to manager
+    if (manager && manager->add_cam_server(cam_server_)) {
+      RCLCPP_WARN(
+        node_->get_logger(),
+        "camera %s add to camera server manager", cam_server_->get_camera_name().c_str());
+    }
   }
 
 private:

--- a/rmoss_cam/include/rmoss_cam/virtual_cam_node.hpp
+++ b/rmoss_cam/include/rmoss_cam/virtual_cam_node.hpp
@@ -22,6 +22,7 @@
 
 #include "rmoss_cam/virtual_cam.hpp"
 #include "rmoss_cam/cam_server.hpp"
+#include "rmoss_cam/cam_server_manager.hpp"
 
 namespace rmoss_cam
 {
@@ -33,6 +34,15 @@ public:
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr get_node_base_interface()
   {
     return node_->get_node_base_interface();
+  }
+  void set_resource_manager(std::shared_ptr<CamServerManager> manager)
+  {
+    // add camera server to manager
+    if (manager && manager->add_cam_server(cam_server_)) {
+      RCLCPP_WARN(
+        node_->get_logger(),
+        "camera %s add to camera server manager", cam_server_->get_camera_name().c_str());
+    }
   }
 
 private:

--- a/rmoss_cam/launch/benchmark.launch.py
+++ b/rmoss_cam/launch/benchmark.launch.py
@@ -1,0 +1,50 @@
+# Copyright 2021 RoboMaster-OSS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    ld = LaunchDescription()
+    image_path = os.path.join(get_package_share_directory('rmoss_cam'), 'resource', 'test.jpg')
+    calibration_path = 'package://rmoss_cam/resource/image_cam_calibration.yaml'
+    virtual_image_cam = Node(
+        package='rmoss_cam',
+        executable='virtual_cam',
+        name='virtual_cam1',
+        parameters=[
+            {'image_path': image_path,
+             'camera_name': 'benchmark_cam1',
+             'camera_info_url': calibration_path,
+             'fps': 100,
+             'autostart': True}],
+        output='screen'
+    )
+    ld.add_action(virtual_image_cam)
+    benchmark_test_node = Node(
+        package='rmoss_cam',
+        executable='benchmark_test',
+        parameters=[
+            {'image_path': image_path,
+             'camera_info_url': calibration_path,
+             'fps': 100,
+             'autostart': True}],
+        output='screen'
+    )
+    ld.add_action(benchmark_test_node)
+    return ld

--- a/rmoss_cam/launch/composition.launch.py
+++ b/rmoss_cam/launch/composition.launch.py
@@ -27,7 +27,7 @@ def generate_launch_description():
     # 创建容器
     rmoss_container = Node(
         name='rmoss_container',
-        package='rclcpp_components',
+        package='rmoss_cam',
         executable='component_container',
         output='screen'
     )
@@ -43,6 +43,15 @@ def generate_launch_description():
                              'camera_name': 'front_camera',
                              'camera_info_url': calibration_path,
                              'fps': 30,
+                             'autostart': True}]),
+            ComposableNode(
+                package='rmoss_cam',
+                plugin='rmoss_cam::VirtualCamNode',
+                name='virtual_image_cam2',
+                parameters=[{'image_path': image_path,
+                             'camera_name': 'front_camera2',
+                             'camera_info_url': calibration_path,
+                             'fps': 10,
                              'autostart': True}])
         ],
     )

--- a/rmoss_cam/src/benchmark_test_main.cpp
+++ b/rmoss_cam/src/benchmark_test_main.cpp
@@ -1,0 +1,122 @@
+// Copyright 2021 RoboMaster-OSS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <thread>
+#include <vector>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rmoss_cam/virtual_cam_node.hpp"
+#include "rmoss_cam/intra_cam_client.hpp"
+
+using namespace std::chrono_literals;
+
+template<typename NodeT>
+std::shared_ptr<std::thread> create_spin_thread(NodeT & node)
+{
+  return std::make_shared<std::thread>(
+    [node]() {
+      rclcpp::executors::SingleThreadedExecutor executor;
+      executor.add_node(node->get_node_base_interface());
+      executor.spin();
+      executor.remove_node(node->get_node_base_interface());
+    });
+}
+
+void benchmark_test(
+  rclcpp::Node::SharedPtr node,
+  std::shared_ptr<rmoss_cam::CamClient> cam_client,
+  std::string camera_name)
+{
+  int num = 0;
+  double first_time;
+  double last_time;
+  double delay_sum = 0;
+  bool ok{false};
+  cam_client->connect(
+    camera_name,
+    [&](const cv::Mat & /*img*/, const rclcpp::Time & stamp) {
+      if (num >= 500) {
+        return;
+      }
+      num++;
+      if (num == 1) {
+        first_time = stamp.seconds();
+      } else if (num == 500) {
+        last_time = stamp.seconds();
+        ok = true;
+      }
+      auto delay = (node->get_clock()->now().seconds() - stamp.seconds());
+      delay_sum = delay_sum + delay;
+    });
+  // wait and disconnect
+  while (!ok) {
+    std::this_thread::sleep_for(100ms);
+  }
+  cam_client->disconnect();
+  // print result
+  std::cout << "result for <" + camera_name << ">:" << std::endl;
+  std::cout << "fps:" << 1.0 * num / (last_time - first_time) << std::endl;
+  std::cout << "delay:" << delay_sum / num << std::endl;
+}
+
+int main(int argc, char * argv[])
+{
+  // create ros2 node
+  rclcpp::init(argc, argv);
+  // spin threads
+  std::vector<std::shared_ptr<std::thread>> threads;
+  // benchmark node
+  auto node = std::make_shared<rclcpp::Node>("benchmark");
+  auto cam_server_manager = std::make_shared<rmoss_cam::CamServerManager>(
+    node->get_node_logging_interface());
+  // cam1: normal node (run by launch file)
+  // cam2: composed node
+  auto node_options2 = rclcpp::NodeOptions();
+  node_options2.arguments({"--ros-args", "-r", std::string("__node:=") + "virtual_cam2", "--"});
+  node_options2.append_parameter_override("camera_name", "benchmark_cam2");
+  auto cam2_node = std::make_shared<rmoss_cam::VirtualCamNode>(node_options2);
+  threads.push_back(create_spin_thread(cam2_node));
+  // cam3: composed node (intra-comunication)
+  auto node_options3 = rclcpp::NodeOptions();
+  node_options3.arguments({"--ros-args", "-r", std::string("__node:=") + "virtual_cam3", "--"});
+  node_options3.append_parameter_override("camera_name", "benchmark_cam3");
+  auto cam3_node = std::make_shared<rmoss_cam::VirtualCamNode>(node_options3);
+  cam3_node->set_resource_manager(cam_server_manager);
+  threads.push_back(create_spin_thread(cam3_node));
+  // create camera clients
+  auto client_node1 = std::make_shared<rclcpp::Node>("client_node1");
+  auto cam_client1 = std::make_shared<rmoss_cam::CamClient>(client_node1);
+  auto client_node2 = std::make_shared<rclcpp::Node>("client_node2");
+  auto cam_client2 = std::make_shared<rmoss_cam::CamClient>(client_node2);
+  auto client_node3 = std::make_shared<rclcpp::Node>("client_node3");
+  auto cam_client3 = std::make_shared<rmoss_cam::IntraCamClient>(client_node3, cam_server_manager);
+  // benchmark test
+  std::this_thread::sleep_for(2s);
+  std::cout << "start test for normal process" << std::endl;
+  benchmark_test(client_node1, cam_client1, "benchmark_cam1");
+  std::this_thread::sleep_for(2s);
+  std::cout << "start test for normal component" << std::endl;
+  benchmark_test(client_node2, cam_client2, "benchmark_cam2");
+  std::this_thread::sleep_for(2s);
+  std::cout << "start test for intra-component" << std::endl;
+  benchmark_test(client_node3, cam_client3, "benchmark_cam3");
+  // wait end
+  for (auto t : threads) {
+    t->join();
+  }
+  rclcpp::shutdown();
+  return 0;
+}

--- a/rmoss_cam/src/benchmark_test_main.cpp
+++ b/rmoss_cam/src/benchmark_test_main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 RoboMaster-OSS
+// Copyright 2022 RoboMaster-OSS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rmoss_cam/src/component_container.cpp
+++ b/rmoss_cam/src/component_container.cpp
@@ -30,9 +30,9 @@
 class CamComponentManager : public rclcpp_components::ComponentManager
 {
 public:
-  CamComponentManager(
+  explict CamComponentManager(
     std::weak_ptr<rclcpp::Executor> executor,
-    std::string node_name = "ComponentManager",
+    const std::string node_name = "ComponentManager",
     const rclcpp::NodeOptions & node_options = rclcpp::NodeOptions()
     .start_parameter_services(false)
     .start_parameter_event_publisher(false))

--- a/rmoss_cam/src/component_container.cpp
+++ b/rmoss_cam/src/component_container.cpp
@@ -30,9 +30,9 @@
 class CamComponentManager : public rclcpp_components::ComponentManager
 {
 public:
-  explict CamComponentManager(
+  explicit CamComponentManager(
     std::weak_ptr<rclcpp::Executor> executor,
-    const std::string node_name = "ComponentManager",
+    const std::string & node_name = "ComponentManager",
     const rclcpp::NodeOptions & node_options = rclcpp::NodeOptions()
     .start_parameter_services(false)
     .start_parameter_event_publisher(false))

--- a/rmoss_cam/src/component_container.cpp
+++ b/rmoss_cam/src/component_container.cpp
@@ -1,0 +1,101 @@
+// Copyright 2022 RoboMaster-OSS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <vector>
+#include <string>
+#include <map>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_components/component_manager.hpp"
+#include "ament_index_cpp/get_resource.hpp"
+#include "class_loader/class_loader.hpp"
+#include "rcpputils/filesystem_helper.hpp"
+#include "rcpputils/split.hpp"
+#include "rmoss_cam/cam_server_manager.hpp"
+#include "rmoss_cam/cam_node_factory.hpp"
+
+// TODO(gezp) :use component_manager_isolated in the next ROS LTS distro Humble.
+class CamComponentManager : public rclcpp_components::ComponentManager
+{
+public:
+  CamComponentManager(
+    std::weak_ptr<rclcpp::Executor> executor,
+    std::string node_name = "ComponentManager",
+    const rclcpp::NodeOptions & node_options = rclcpp::NodeOptions()
+    .start_parameter_services(false)
+    .start_parameter_event_publisher(false))
+  : rclcpp_components::ComponentManager::ComponentManager(executor, node_name, node_options)
+  {
+    cam_server_manager_ = std::make_shared<rmoss_cam::CamServerManager>(
+      this->get_node_logging_interface());
+  }
+
+protected:
+  std::shared_ptr<rclcpp_components::NodeFactory>
+  create_component_factory(const ComponentResource & resource) override
+  {
+    std::string library_path = resource.second;
+    std::string class_name = resource.first;
+    std::string fq_class_name = "rclcpp_components::NodeFactoryTemplate<" + class_name + ">";
+    std::string cam_class_name = "rmoss_cam::CamNodeFactoryTemplate<" + class_name + ">";
+    class_loader::ClassLoader * loader;
+    if (loaders_.find(library_path) == loaders_.end()) {
+      RCLCPP_INFO(get_logger(), "Load Library: %s", library_path.c_str());
+      try {
+        loaders_[library_path] = std::make_unique<class_loader::ClassLoader>(library_path);
+      } catch (const std::exception & ex) {
+        throw rclcpp_components::ComponentManagerException(
+                "Failed to load library: " + std::string(ex.what()));
+      } catch (...) {
+        throw rclcpp_components::ComponentManagerException("Failed to load library");
+      }
+    }
+    loader = loaders_[library_path].get();
+    // try to load Camera Node (CamServer, CamClient)
+    auto classes = loader->getAvailableClasses<rmoss_cam::CamNodeFactory>();
+    for (const auto & clazz : classes) {
+      RCLCPP_INFO(get_logger(), "Found class related to Camera: %s", clazz.c_str());
+      if (clazz == cam_class_name) {
+        RCLCPP_INFO(get_logger(), "Instantiate class: %s", clazz.c_str());
+        auto result = loader->createInstance<rmoss_cam::CamNodeFactory>(clazz);
+        result->set_resource_manager(cam_server_manager_);
+        return result;
+      }
+    }
+    // try to load normal Node
+    auto classes2 = loader->getAvailableClasses<rclcpp_components::NodeFactory>();
+    for (const auto & clazz : classes2) {
+      RCLCPP_INFO(get_logger(), "Found class: %s", clazz.c_str());
+      if (clazz == class_name || clazz == fq_class_name) {
+        RCLCPP_INFO(get_logger(), "Instantiate class: %s", clazz.c_str());
+        return loader->createInstance<rclcpp_components::NodeFactory>(clazz);
+      }
+    }
+    return {};
+  }
+
+private:
+  std::map<std::string, std::unique_ptr<class_loader::ClassLoader>> loaders_;
+  std::shared_ptr<rmoss_cam::CamServerManager> cam_server_manager_;
+};
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  auto exec = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
+  auto node = std::make_shared<CamComponentManager>(exec);
+  exec->add_node(node);
+  exec->spin();
+}

--- a/rmoss_cam/src/usb_cam/usb_cam_node.cpp
+++ b/rmoss_cam/src/usb_cam/usb_cam_node.cpp
@@ -16,11 +16,6 @@
 
 #include <memory>
 #include <string>
-#include <vector>
-#include <chrono>
-
-using namespace std::chrono_literals;
-
 
 namespace rmoss_cam
 {
@@ -39,9 +34,9 @@ UsbCamNode::UsbCamNode(const rclcpp::NodeOptions & options)
 
 }  // namespace rmoss_cam
 
-#include "rclcpp_components/register_node_macro.hpp"
+#include "rmoss_cam/register_node_macro.hpp"
 
 // Register the component with class_loader.
 // This acts as a sort of entry point, allowing the component to be discoverable when its library
 // is being loaded into a running process.
-RCLCPP_COMPONENTS_REGISTER_NODE(rmoss_cam::UsbCamNode)
+RMOSS_CAM_COMPONENTS_REGISTER_NODE(rmoss_cam::UsbCamNode)

--- a/rmoss_cam/src/virtual_cam/virtual_cam_node.cpp
+++ b/rmoss_cam/src/virtual_cam/virtual_cam_node.cpp
@@ -45,9 +45,9 @@ VirtualCamNode::VirtualCamNode(const rclcpp::NodeOptions & options)
 
 }  // namespace rmoss_cam
 
-#include "rclcpp_components/register_node_macro.hpp"
+#include "rmoss_cam/register_node_macro.hpp"
 
 // Register the component with class_loader.
 // This acts as a sort of entry point, allowing the component to be discoverable when its library
 // is being loaded into a running process.
-RCLCPP_COMPONENTS_REGISTER_NODE(rmoss_cam::VirtualCamNode)
+RMOSS_CAM_COMPONENTS_REGISTER_NODE(rmoss_cam::VirtualCamNode)


### PR DESCRIPTION
解决https://github.com/robomaster-oss/rmoss_core/issues/8.

增加基于`CamServerManager`的`component container`，实现容器内节点之间图像直接传输，而不经过ROS通信机制。
* 定义新的`CamNodeFactory` (继承`rclcpp_components::NodeFactory`), 定义新的的API，将`CamServerManager`传递给Node节点
* 定义新的`CamComponentManager` (继承`rclcpp_components::ComponentManager`)，覆盖`create_component_factory()` API, ，优先尝试加载`CamNodeFactory`类型，否则加载普通rclcpp_components类型节点。