### PR TITLE
replace cv_bridge with direct converter for image msg

### DIFF
--- a/rmoss_cam/src/benchmark_test_main.cpp
+++ b/rmoss_cam/src/benchmark_test_main.cpp
@@ -36,8 +36,8 @@ std::shared_ptr<std::thread> create_spin_thread(NodeT & node)
 }
 
 std::shared_ptr<rmoss_cam::VirtualCamNode> create_cam_node(
-  std::string node_name,
-  std::string camera_name,
+  const std::string & node_name,
+  const std::string & camera_name,
   bool use_intra_process_comms = false)
 {
   auto node_options = rclcpp::NodeOptions().use_intra_process_comms(use_intra_process_comms);

--- a/rmoss_cam/src/benchmark_test_main.cpp
+++ b/rmoss_cam/src/benchmark_test_main.cpp
@@ -35,6 +35,17 @@ std::shared_ptr<std::thread> create_spin_thread(NodeT & node)
     });
 }
 
+std::shared_ptr<rmoss_cam::VirtualCamNode> create_cam_node(
+  std::string node_name,
+  std::string camera_name,
+  bool use_intra_process_comms = false)
+{
+  auto node_options = rclcpp::NodeOptions().use_intra_process_comms(use_intra_process_comms);
+  node_options.arguments({"--ros-args", "-r", std::string("__node:=") + node_name, "--"});
+  node_options.append_parameter_override("camera_name", camera_name);
+  return std::make_shared<rmoss_cam::VirtualCamNode>(node_options);
+}
+
 void benchmark_test(
   rclcpp::Node::SharedPtr node,
   std::shared_ptr<rmoss_cam::CamClient> cam_client,
@@ -84,39 +95,44 @@ int main(int argc, char * argv[])
     node->get_node_logging_interface());
   // cam1: normal node (run by launch file)
   // cam2: composed node
-  auto node_options2 = rclcpp::NodeOptions();
-  node_options2.arguments({"--ros-args", "-r", std::string("__node:=") + "virtual_cam2", "--"});
-  node_options2.append_parameter_override("camera_name", "benchmark_cam2");
-  auto cam2_node = std::make_shared<rmoss_cam::VirtualCamNode>(node_options2);
+  auto cam2_node = create_cam_node("virtual_cam2", "benchmark_cam2");
   threads.push_back(create_spin_thread(cam2_node));
-  // cam3: composed node (intra-comunication)
-  auto node_options3 = rclcpp::NodeOptions();
-  node_options3.arguments({"--ros-args", "-r", std::string("__node:=") + "virtual_cam3", "--"});
-  node_options3.append_parameter_override("camera_name", "benchmark_cam3");
-  auto cam3_node = std::make_shared<rmoss_cam::VirtualCamNode>(node_options3);
-  cam3_node->set_resource_manager(cam_server_manager);
+  // cam2: composed node with rclcpp intra-comms
+  auto cam3_node = create_cam_node("virtual_cam3", "benchmark_cam3", true);
   threads.push_back(create_spin_thread(cam3_node));
+  // cam3: composed node with rmoss intra-comms
+  auto cam4_node = create_cam_node("virtual_cam4", "benchmark_cam4");
+  cam4_node->set_resource_manager(cam_server_manager);
+  threads.push_back(create_spin_thread(cam4_node));
   // create camera clients
   auto client_node1 = std::make_shared<rclcpp::Node>("client_node1");
   auto cam_client1 = std::make_shared<rmoss_cam::CamClient>(client_node1);
   auto client_node2 = std::make_shared<rclcpp::Node>("client_node2");
   auto cam_client2 = std::make_shared<rmoss_cam::CamClient>(client_node2);
-  auto client_node3 = std::make_shared<rclcpp::Node>("client_node3");
-  auto cam_client3 = std::make_shared<rmoss_cam::IntraCamClient>(client_node3, cam_server_manager);
+  auto client_node3 = std::make_shared<rclcpp::Node>(
+    "client_node3",
+    rclcpp::NodeOptions().use_intra_process_comms(true));
+  auto cam_client3 = std::make_shared<rmoss_cam::CamClient>(client_node3);
+  auto client_node4 = std::make_shared<rclcpp::Node>("client_node4");
+  auto cam_client4 = std::make_shared<rmoss_cam::IntraCamClient>(client_node4, cam_server_manager);
   // benchmark test
-  std::this_thread::sleep_for(2s);
-  std::cout << "start test for normal process" << std::endl;
+  std::this_thread::sleep_for(1s);
+  std::cout << "start test for normal multi-process" << std::endl;
   benchmark_test(client_node1, cam_client1, "benchmark_cam1");
-  std::this_thread::sleep_for(2s);
-  std::cout << "start test for normal component" << std::endl;
+  std::this_thread::sleep_for(1s);
+  std::cout << "start test for normal composition" << std::endl;
   benchmark_test(client_node2, cam_client2, "benchmark_cam2");
-  std::this_thread::sleep_for(2s);
-  std::cout << "start test for intra-component" << std::endl;
+  std::this_thread::sleep_for(1s);
+  std::cout << "start test for composition with rclcpp intra-comms" << std::endl;
   benchmark_test(client_node3, cam_client3, "benchmark_cam3");
+  std::this_thread::sleep_for(1s);
+  std::cout << "start test for rmoss intra-comms" << std::endl;
+  benchmark_test(client_node4, cam_client4, "benchmark_cam4");
   // wait end
+  std::this_thread::sleep_for(1s);
+  rclcpp::shutdown();
   for (auto t : threads) {
     t->join();
   }
-  rclcpp::shutdown();
   return 0;
 }

--- a/rmoss_cam/src/benchmark_test_main.cpp
+++ b/rmoss_cam/src/benchmark_test_main.cpp
@@ -97,10 +97,10 @@ int main(int argc, char * argv[])
   // cam2: composed node
   auto cam2_node = create_cam_node("virtual_cam2", "benchmark_cam2");
   threads.push_back(create_spin_thread(cam2_node));
-  // cam2: composed node with rclcpp intra-comms
+  // cam3: composed node with rclcpp intra-comms
   auto cam3_node = create_cam_node("virtual_cam3", "benchmark_cam3", true);
   threads.push_back(create_spin_thread(cam3_node));
-  // cam3: composed node with rmoss intra-comms
+  // cam4: composed node with rmoss intra-comms
   auto cam4_node = create_cam_node("virtual_cam4", "benchmark_cam4");
   cam4_node->set_resource_manager(cam_server_manager);
   threads.push_back(create_spin_thread(cam4_node));

--- a/rmoss_cam/src/benchmark_test_main.cpp
+++ b/rmoss_cam/src/benchmark_test_main.cpp
@@ -126,7 +126,7 @@ int main(int argc, char * argv[])
   std::cout << "start test for composition with rclcpp intra-comms" << std::endl;
   benchmark_test(client_node3, cam_client3, "benchmark_cam3");
   std::this_thread::sleep_for(1s);
-  std::cout << "start test for rmoss intra-comms" << std::endl;
+  std::cout << "start test for composition with rmoss intra-comms" << std::endl;
   benchmark_test(client_node4, cam_client4, "benchmark_cam4");
   // wait end
   std::this_thread::sleep_for(1s);

--- a/rmoss_cam/src/cam_server.cpp
+++ b/rmoss_cam/src/cam_server.cpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <vector>
 #include <chrono>
+#include <utility>
 
 #include "cv_bridge/cv_bridge.h"
 #include "sensor_msgs/msg/image.hpp"
@@ -106,7 +107,9 @@ CamServer::CamServer(
       node_->get_logger(), "Calibration file '%s' is missing", camera_info_url.c_str());
   }
   // create image publisher
-  img_pub_ = node_->create_publisher<sensor_msgs::msg::Image>(camera_name_ + "/image_raw", 1);
+  img_pub_ = node_->create_publisher<sensor_msgs::msg::Image>(
+    camera_name_ + "/image_raw",
+    rclcpp::SensorDataQoS());
   init_timer();
   // create GetCameraInfo service
   using namespace std::placeholders;
@@ -134,11 +137,15 @@ void CamServer::init_timer()
         }
         // publish image msg
         if (img_pub_->get_subscription_count() > 0) {
-          auto header = std_msgs::msg::Header();
-          header.stamp = stamp;
-          sensor_msgs::msg::Image::SharedPtr img_msg = cv_bridge::CvImage(
-            header, "bgr8", img_).toImageMsg();
-          img_pub_->publish(*img_msg);
+          sensor_msgs::msg::Image::UniquePtr msg = std::make_unique<sensor_msgs::msg::Image>();
+          msg->header.stamp = stamp;
+          msg->encoding = "bgr8";
+          msg->width = img_.cols;
+          msg->height = img_.rows;
+          msg->step = static_cast<sensor_msgs::msg::Image::_step_type>(img_.step);
+          msg->is_bigendian = false;
+          msg->data.assign(img_.datastart, img_.dataend);
+          img_pub_->publish(std::move(msg));
         }
       } else {
         // try to reopen camera

--- a/rmoss_cam/src/cam_server.cpp
+++ b/rmoss_cam/src/cam_server.cpp
@@ -107,9 +107,7 @@ CamServer::CamServer(
       node_->get_logger(), "Calibration file '%s' is missing", camera_info_url.c_str());
   }
   // create image publisher
-  img_pub_ = node_->create_publisher<sensor_msgs::msg::Image>(
-    camera_name_ + "/image_raw",
-    rclcpp::SensorDataQoS());
+  img_pub_ = node_->create_publisher<sensor_msgs::msg::Image>(camera_name_ + "/image_raw", 1);
   init_timer();
   // create GetCameraInfo service
   using namespace std::placeholders;


### PR DESCRIPTION
解决https://github.com/robomaster-oss/rmoss_core/issues/8.

在rmoss_cam中，使用[cv_bridge::CvImage](https://github.com/robomaster-oss/rmoss_core/blob/27b8664177cda3c561251dcf668e9c1167de023e/rmoss_cam/src/cam_server.cpp#L139-L140)进行`cv::Mat`与`sensor_msgs::msg::Image`之间的转换，该部分性能不是很好，[ros2/demos/intra_process_demo](https://github.com/ros2/demos/blob/dba4daa88f5b1474485b4063f21973b19f2f3477/intra_process_demo/include/image_pipeline/camera_node.hpp#L97-L103)提供了相关直接转换的代码，可以直接采用。

* 移除`cv_bridge`转换模块。
* msg类型使用`unique_ptr`，支持rclcpp `use_intra_process_comms` 特性。
* benchmark 增加 rclcpp `use_intra_process_comms`  测试。
