### PR TITLE
update rmoss_cam

### DIFF
--- a/rmoss_cam/include/rmoss_cam/cam_client.hpp
+++ b/rmoss_cam/include/rmoss_cam/cam_client.hpp
@@ -48,8 +48,8 @@ public:
   bool get_camera_info(sensor_msgs::msg::CameraInfo & info);
 
 private:
-  bool connect_intra();
-  void disconnect_intra();
+  bool create_intra_callback();
+  void remove_intra_callback();
 
 protected:
   rclcpp::Node::SharedPtr node_;
@@ -71,6 +71,7 @@ protected:
   std::unique_ptr<std::thread> callback_thread_;
   std::shared_ptr<CamServer> cur_server_;
   int cur_server_cb_idx_{-1};
+  bool intra_ok_{false};
 };
 }  // namespace rmoss_cam
 

--- a/rmoss_cam/include/rmoss_cam/cam_client.hpp
+++ b/rmoss_cam/include/rmoss_cam/cam_client.hpp
@@ -39,17 +39,23 @@ public:
   ~CamClient();
 
   void set_camera_name(const std::string & camera_name);
+  void set_camera_callback(Callback cb);
   void set_cam_server_manager(std::shared_ptr<CamServerManager> manager);
 
-  virtual bool connect(Callback cb);
-  virtual void disconnect();
+  bool connect();
+  void disconnect();
   bool is_connect() {return is_connected_;}
   bool get_camera_info(sensor_msgs::msg::CameraInfo & info);
+
+private:
+  bool connect_intra();
+  void disconnect_intra();
 
 protected:
   rclcpp::Node::SharedPtr node_;
   std::string camera_name_;
   // capture image by topic
+  Callback cb_;
   rclcpp::CallbackGroup::SharedPtr callback_group_{nullptr};
   rclcpp::executors::SingleThreadedExecutor::SharedPtr executor_;
   std::unique_ptr<std::thread> executor_thread_;

--- a/rmoss_cam/include/rmoss_cam/cam_client.hpp
+++ b/rmoss_cam/include/rmoss_cam/cam_client.hpp
@@ -36,14 +36,12 @@ public:
   typedef std::function<void (const cv::Mat &, const rclcpp::Time &)> Callback;
   explicit CamClient(rclcpp::Node::SharedPtr node)
   : node_(node) {}
-  [[deprecated("Use connect() instead of setting camera and callback in constructor")]]
-  CamClient(
-    rclcpp::Node::SharedPtr node, std::string camera_name, Callback process_fn,
-    bool spin_thread = true);
   ~CamClient();
 
+  void set_camera_name(const std::string & camera_name);
   void set_cam_server_manager(std::shared_ptr<CamServerManager> manager);
-  virtual bool connect(const std::string & camera_name, Callback cb);
+
+  virtual bool connect(Callback cb);
   virtual void disconnect();
   bool is_connect() {return is_connected_;}
   bool get_camera_info(sensor_msgs::msg::CameraInfo & info);

--- a/rmoss_cam/include/rmoss_cam/cam_server.hpp
+++ b/rmoss_cam/include/rmoss_cam/cam_server.hpp
@@ -65,6 +65,7 @@ private:
   std::shared_ptr<CamInterface> cam_intercace_;
   //
   std::string camera_name_{"camera"};
+  std::string camera_frame_id_{""};
   bool run_flag_{false};
   bool cam_status_ok_{false};
   // data

--- a/rmoss_cam/src/benchmark_test_main.cpp
+++ b/rmoss_cam/src/benchmark_test_main.cpp
@@ -56,8 +56,8 @@ void benchmark_test(
   double last_time;
   double delay_sum = 0;
   bool ok{false};
+  cam_client->set_camera_name(camera_name);
   cam_client->connect(
-    camera_name,
     [&](const cv::Mat & /*img*/, const rclcpp::Time & stamp) {
       if (num >= 500) {
         return;

--- a/rmoss_cam/src/benchmark_test_main.cpp
+++ b/rmoss_cam/src/benchmark_test_main.cpp
@@ -57,7 +57,7 @@ void benchmark_test(
   double delay_sum = 0;
   bool ok{false};
   cam_client->set_camera_name(camera_name);
-  cam_client->connect(
+  cam_client->set_camera_callback(
     [&](const cv::Mat & /*img*/, const rclcpp::Time & stamp) {
       if (num >= 500) {
         return;
@@ -72,6 +72,7 @@ void benchmark_test(
       auto delay = (node->get_clock()->now().seconds() - stamp.seconds());
       delay_sum = delay_sum + delay;
     });
+  cam_client->connect();
   // wait and disconnect
   while (!ok) {
     std::this_thread::sleep_for(100ms);

--- a/rmoss_cam/src/cam_client.cpp
+++ b/rmoss_cam/src/cam_client.cpp
@@ -34,10 +34,15 @@ CamClient::~CamClient()
 
 void CamClient::set_cam_server_manager(std::shared_ptr<CamServerManager> manager)
 {
-  if (!is_connected_) {
-    cam_server_manager_ = manager;
-    use_intra_comms_ = (manager != nullptr);
+  if (is_connected_) {
+    RCLCPP_ERROR(
+      node_->get_logger(),
+      "[set_cam_server_manager] camera %s is already connected, please use disconnect().",
+      camera_name_.c_str());
+    return;
   }
+  cam_server_manager_ = manager;
+  use_intra_comms_ = (manager != nullptr);
 }
 
 void CamClient::set_camera_name(const std::string & camera_name)
@@ -46,18 +51,26 @@ void CamClient::set_camera_name(const std::string & camera_name)
     RCLCPP_ERROR(
       node_->get_logger(),
       "[set_camera_name] camera %s is already connected, please use disconnect().",
-      camera_name.c_str());
+      camera_name_.c_str());
     return;
   }
   camera_name_ = camera_name;
 }
 
-bool CamClient::connect(Callback cb)
-{
-  if (camera_name_ == "") {
-    RCLCPP_ERROR(node_->get_logger(), "[connect] camera_name is invaild!");
-    return false;
+void CamClient::set_camera_callback(Callback cb){
+  if (is_connected_) {
+    RCLCPP_ERROR(
+      node_->get_logger(),
+      "[set_camera_callback] camera %s is already connected, please use disconnect().",
+      camera_name_.c_str());
+    return;
   }
+  cb_ = cb;
+}
+
+bool CamClient::connect()
+{
+  // check
   if (is_connected_) {
     RCLCPP_ERROR(
       node_->get_logger(),
@@ -65,12 +78,23 @@ bool CamClient::connect(Callback cb)
       camera_name_.c_str());
     return false;
   }
-  // set new camera
-  if (!use_intra_comms_) {
-    auto img_cb = [cb](const sensor_msgs::msg::Image::ConstSharedPtr msg) {
+  if (camera_name_ == "") {
+    RCLCPP_ERROR(node_->get_logger(), "[connect] camera_name is invaild!");
+    return false;
+  }
+  if (!cb_) {
+    RCLCPP_ERROR(node_->get_logger(), "[connect] callback is invaild!");
+    return false; 
+  }
+  // connect
+  if (use_intra_comms_) {
+    return connect_intra(); 
+  } else {
+    // default by ros topic
+    auto img_cb = [this](const sensor_msgs::msg::Image::ConstSharedPtr msg) {
         auto img =
           cv::Mat(msg->height, msg->width, CV_8UC3, const_cast<unsigned char *>(msg->data.data()));
-        cb(img, msg->header.stamp);
+        cb_(img, msg->header.stamp);
       };
     auto sub_opt = rclcpp::SubscriptionOptions();
     callback_group_ = node_->create_callback_group(
@@ -82,36 +106,44 @@ bool CamClient::connect(Callback cb)
     executor_->add_callback_group(callback_group_, node_->get_node_base_interface());
     executor_thread_ = std::make_unique<std::thread>([&]() {executor_->spin();});
     is_connected_ = true;
-  } else {
-    auto server = cam_server_manager_->get_cam_server(camera_name_);
-    if (!server) {
-      RCLCPP_ERROR(node_->get_logger(), "failed to find camera server %s.", camera_name_.c_str());
-      return false;
-    }
-    // set new camera
-    cur_server_ = server;
-    is_connected_ = true;
-    callback_thread_ = std::make_unique<std::thread>(
-      [this, cb]() {
-        while (is_connected_) {
-          std::unique_lock<std::mutex> lock(mut_);
-          cond_.wait(lock);
-          if (is_connected_) {
-            cb(img_, stamp_);
-          }
-        }
-      });
-    cur_server_cb_idx_ = cur_server_->add_callback(
-      [this](const cv::Mat & img, const rclcpp::Time & stamp) {
-        if (mut_.try_lock()) {
-          img.copyTo(img_);
-          stamp_ = stamp;
-          mut_.unlock();
-          cond_.notify_one();
-        }
-      });
   }
   return true;
+}
+
+bool CamClient::connect_intra(){
+  auto server = cam_server_manager_->get_cam_server(camera_name_);
+  if (!server) {
+    RCLCPP_ERROR(node_->get_logger(), "failed to find camera server %s.", camera_name_.c_str());
+    return false;
+  }
+  // set new camera
+  cur_server_ = server;
+  is_connected_ = true;
+  callback_thread_ = std::make_unique<std::thread>(
+    [this]() {
+      while (is_connected_) {
+        std::unique_lock<std::mutex> lock(mut_);
+        cond_.wait(lock);
+        if (is_connected_) {
+          cb_(img_, stamp_);
+        }
+      }
+    });
+  cur_server_cb_idx_ = cur_server_->add_callback(
+    [this](const cv::Mat & img, const rclcpp::Time & stamp) {
+      if (mut_.try_lock()) {
+        img.copyTo(img_);
+        stamp_ = stamp;
+        mut_.unlock();
+        cond_.notify_one();
+      }
+    });
+  return true;
+}
+void CamClient::disconnect_intra(){
+  cur_server_->remove_callback(cur_server_cb_idx_);
+  cond_.notify_one();
+  callback_thread_->join();
 }
 
 void CamClient::disconnect()
@@ -119,17 +151,15 @@ void CamClient::disconnect()
   if (is_connected_) {
     camera_name_ = "";
     is_connected_ = false;
-    if (!use_intra_comms_) {
+    if (use_intra_comms_) {
+      disconnect_intra();
+    } else {
       // cancel the prevoius camera
       executor_->cancel();
       executor_thread_->join();
       executor_.reset();
       executor_thread_.reset();
       img_sub_.reset();
-    } else {
-      cur_server_->remove_callback(cur_server_cb_idx_);
-      cond_.notify_one();
-      callback_thread_->join();
     }
   }
 }

--- a/rmoss_cam/src/cam_client.cpp
+++ b/rmoss_cam/src/cam_client.cpp
@@ -24,13 +24,6 @@ using namespace std::chrono_literals;
 
 namespace rmoss_cam
 {
-CamClient::CamClient(
-  rclcpp::Node::SharedPtr node, std::string camera_name, Callback process_fn, bool spin_thread)
-: node_(node)
-{
-  (void)spin_thread;
-  connect(camera_name, process_fn);
-}
 
 CamClient::~CamClient()
 {
@@ -47,16 +40,31 @@ void CamClient::set_cam_server_manager(std::shared_ptr<CamServerManager> manager
   }
 }
 
-bool CamClient::connect(const std::string & camera_name, Callback cb)
+void CamClient::set_camera_name(const std::string & camera_name)
 {
   if (is_connected_) {
     RCLCPP_ERROR(
       node_->get_logger(),
-      "[connect] camera %s is already connected, please use disconnect().",
+      "[set_camera_name] camera %s is already connected, please use disconnect().",
       camera_name.c_str());
-    return false;
+    return;
   }
   camera_name_ = camera_name;
+}
+
+bool CamClient::connect(Callback cb)
+{
+  if (camera_name_ == "") {
+    RCLCPP_ERROR(node_->get_logger(), "[connect] camera_name is invaild!");
+    return false;
+  }
+  if (is_connected_) {
+    RCLCPP_ERROR(
+      node_->get_logger(),
+      "[connect] camera %s is already connected, please use disconnect().",
+      camera_name_.c_str());
+    return false;
+  }
   // set new camera
   if (!use_intra_comms_) {
     auto img_cb = [cb](const sensor_msgs::msg::Image::ConstSharedPtr msg) {
@@ -69,15 +77,15 @@ bool CamClient::connect(const std::string & camera_name, Callback cb)
       rclcpp::CallbackGroupType::MutuallyExclusive, false);
     sub_opt.callback_group = callback_group_;
     img_sub_ = node_->create_subscription<sensor_msgs::msg::Image>(
-      camera_name + "/image_raw", 1, img_cb, sub_opt);
+      camera_name_ + "/image_raw", 1, img_cb, sub_opt);
     executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
     executor_->add_callback_group(callback_group_, node_->get_node_base_interface());
     executor_thread_ = std::make_unique<std::thread>([&]() {executor_->spin();});
     is_connected_ = true;
   } else {
-    auto server = cam_server_manager_->get_cam_server(camera_name);
+    auto server = cam_server_manager_->get_cam_server(camera_name_);
     if (!server) {
-      RCLCPP_ERROR(node_->get_logger(), "failed to find camera server %s.", camera_name.c_str());
+      RCLCPP_ERROR(node_->get_logger(), "failed to find camera server %s.", camera_name_.c_str());
       return false;
     }
     // set new camera
@@ -129,7 +137,7 @@ void CamClient::disconnect()
 bool CamClient::get_camera_info(sensor_msgs::msg::CameraInfo & info)
 {
   if (camera_name_ == "") {
-    RCLCPP_ERROR(node_->get_logger(), "[get_camera_info] camera should be connected!");
+    RCLCPP_ERROR(node_->get_logger(), "[get_camera_info] camera_name is invaild!");
     return false;
   }
   auto callback_group = node_->create_callback_group(

--- a/rmoss_cam/src/cam_server.cpp
+++ b/rmoss_cam/src/cam_server.cpp
@@ -68,11 +68,16 @@ CamServer::CamServer(
   std::string camera_info_url = "";
   // declare parameters
   node->declare_parameter("camera_name", camera_name_);
+  node->declare_parameter("frame_id", camera_frame_id_);
   node->declare_parameter("camera_info_url", camera_info_url);
   node->declare_parameter("autostart", run_flag_);
   node->get_parameter("camera_name", camera_name_);
+  node->get_parameter("frame_id", camera_frame_id_);
   node->get_parameter("camera_info_url", camera_info_url);
   node->get_parameter("autostart", run_flag_);
+  if (camera_frame_id_ = "") {
+    camera_frame_id_ = camera_name_ + "_optical";
+  }
   // 相机参数获取并设置，配置文件中的值会覆盖默认值
   int data;
   constexpr int param_num = sizeof(kCamParamTypes) / sizeof(CamParamType);
@@ -137,7 +142,7 @@ void CamServer::init_timer()
         if (img_pub_->get_subscription_count() > 0) {
           sensor_msgs::msg::Image::UniquePtr msg = std::make_unique<sensor_msgs::msg::Image>();
           msg->header.stamp = stamp;
-          msg->header.frame_id = camera_name_;
+          msg->header.frame_id = camera_frame_id_;
           msg->encoding = "bgr8";
           msg->width = img_.cols;
           msg->height = img_.rows;

--- a/rmoss_cam/src/cam_server.cpp
+++ b/rmoss_cam/src/cam_server.cpp
@@ -75,7 +75,7 @@ CamServer::CamServer(
   node->get_parameter("frame_id", camera_frame_id_);
   node->get_parameter("camera_info_url", camera_info_url);
   node->get_parameter("autostart", run_flag_);
-  if (camera_frame_id_ = "") {
+  if (camera_frame_id_ == "") {
     camera_frame_id_ = camera_name_ + "_optical";
   }
   // 相机参数获取并设置，配置文件中的值会覆盖默认值

--- a/rmoss_cam/src/cam_server.cpp
+++ b/rmoss_cam/src/cam_server.cpp
@@ -112,7 +112,7 @@ CamServer::CamServer(
   // create GetCameraInfo service
   using namespace std::placeholders;
   get_camera_info_srv_ = node->create_service<rmoss_interfaces::srv::GetCameraInfo>(
-    camera_name_ + "get_camera_info",
+    camera_name_ + "/get_camera_info",
     std::bind(&CamServer::get_camera_info_cb, this, _1, _2));
   init_task_manager();
   RCLCPP_INFO(node_->get_logger(), "init successfully!");
@@ -137,6 +137,7 @@ void CamServer::init_timer()
         if (img_pub_->get_subscription_count() > 0) {
           sensor_msgs::msg::Image::UniquePtr msg = std::make_unique<sensor_msgs::msg::Image>();
           msg->header.stamp = stamp;
+          msg->header.frame_id = camera_name_;
           msg->encoding = "bgr8";
           msg->width = img_.cols;
           msg->height = img_.rows;

--- a/rmoss_cam/src/image_task_demo_node.cpp
+++ b/rmoss_cam/src/image_task_demo_node.cpp
@@ -51,8 +51,8 @@ void ImageTaskDemoNode::init()
   cam_client_->set_camera_name(camera_name_);
   cam_client_->set_camera_callback(
     [this](const cv::Mat & img, const rclcpp::Time & stamp) {
-        this->process(img, stamp);
-      });
+      this->process(img, stamp);
+    });
   // wait to connect camera
   bool ret = false;
   while (!ret) {

--- a/rmoss_cam/src/image_task_demo_node.cpp
+++ b/rmoss_cam/src/image_task_demo_node.cpp
@@ -48,6 +48,7 @@ void ImageTaskDemoNode::init()
   if (cam_server_manager_) {
     cam_client_->set_cam_server_manager(cam_server_manager_);
   }
+  cam_client_->set_camera_name(camera_name_);
   // wait to connect camera
   bool ret = false;
   while (!ret) {

--- a/rmoss_cam/src/image_task_demo_node.cpp
+++ b/rmoss_cam/src/image_task_demo_node.cpp
@@ -52,7 +52,6 @@ void ImageTaskDemoNode::init()
   bool ret = false;
   while (!ret) {
     ret = cam_client_->connect(
-      camera_name_,
       [this](const cv::Mat & img, const rclcpp::Time & stamp)
       {
         this->process(img, stamp);

--- a/rmoss_cam/src/image_task_demo_node.cpp
+++ b/rmoss_cam/src/image_task_demo_node.cpp
@@ -49,14 +49,14 @@ void ImageTaskDemoNode::init()
     cam_client_->set_cam_server_manager(cam_server_manager_);
   }
   cam_client_->set_camera_name(camera_name_);
+  cam_client_->set_camera_callback(
+    [this](const cv::Mat & img, const rclcpp::Time & stamp) {
+        this->process(img, stamp);
+      });
   // wait to connect camera
   bool ret = false;
   while (!ret) {
-    ret = cam_client_->connect(
-      [this](const cv::Mat & img, const rclcpp::Time & stamp)
-      {
-        this->process(img, stamp);
-      });
+    ret = cam_client_->connect();
     if (!ret) {
       RCLCPP_WARN(node_->get_logger(), "wait 1s to open camera.");
       std::this_thread::sleep_for(1s);

--- a/rmoss_cam/test/test_cam_client.cpp
+++ b/rmoss_cam/test/test_cam_client.cpp
@@ -41,10 +41,11 @@ TEST(CamClient, callback)
   executor->add_node(node2);
   int num = 0;
   cam_client->set_camera_name("test_camera");
-  cam_client->connect(
+  cam_client->set_camera_callback(
     [&](const cv::Mat & /*img*/, const rclcpp::Time & /*stamp*/) {
       num++;
     });
+  cam_client->connect();
   for (int i = 0; i < 10; i++) {
     executor->spin_some();
     std::this_thread::sleep_for(10ms);
@@ -79,10 +80,11 @@ TEST(CamClient, intra_comms)
   executor->add_node(node2);
   int num = 0;
   cam_client->set_camera_name("test_camera");
-  cam_client->connect(
+  cam_client->set_camera_callback(
     [&](const cv::Mat & /*img*/, const rclcpp::Time & /*stamp*/) {
       num++;
     });
+  cam_client->connect();
   for (int i = 0; i < 10; i++) {
     executor->spin_some();
     std::this_thread::sleep_for(10ms);

--- a/rmoss_cam/test/test_cam_client.cpp
+++ b/rmoss_cam/test/test_cam_client.cpp
@@ -40,8 +40,8 @@ TEST(CamClient, callback)
   executor->add_node(node);
   executor->add_node(node2);
   int num = 0;
+  cam_client->set_camera_name("test_camera");
   cam_client->connect(
-    "test_camera",
     [&](const cv::Mat & /*img*/, const rclcpp::Time & /*stamp*/) {
       num++;
     });
@@ -78,8 +78,8 @@ TEST(CamClient, intra_comms)
   executor->add_node(node1);
   executor->add_node(node2);
   int num = 0;
+  cam_client->set_camera_name("test_camera");
   cam_client->connect(
-    "test_camera",
     [&](const cv::Mat & /*img*/, const rclcpp::Time & /*stamp*/) {
       num++;
     });


### PR DESCRIPTION
rmoss_cam更新
* `CamClient` 移除弃用的构造函数.
* `CamClient` 修改`connect() `，去除参数传递，增加`set_camera_name()` 和`set_camera_callback()` API.
* `CamServer`  修复`get_camera_info` topic.
* `CamServer` 增加设置图像消息`frame_id`.