### PR TITLE
fix(rm_base): fix a bug of calling set_param() in open()

### DIFF
--- a/rmoss_base/src/transporter_driver/uart_transporter.cpp
+++ b/rmoss_base/src/transporter_driver/uart_transporter.cpp
@@ -162,7 +162,7 @@ bool UartTransporter::open()
     return false;
   }
   // 设置串口数据帧格式
-  if (set_param(speed_, flow_ctrl_, databits_, stopbits_, parity_)) {
+  if (!set_param(speed_, flow_ctrl_, databits_, stopbits_, parity_)) {
     return false;
   }
   is_open_ = true;


### PR DESCRIPTION
## fix open()
在打开串口的函数open()中， set_param()函数用于设置串口数据帧格式。
设置参数失败返回false，应当执行if中的return false，设置成功则跳过。
此处修改了逻辑错误，将if判断改为 !set_param() 。